### PR TITLE
Trim spaces in arguments when splitting array

### DIFF
--- a/SourceCode/Common/Casbin/Casbin.Resolve.pas
+++ b/SourceCode/Common/Casbin/Casbin.Resolve.pas
@@ -144,9 +144,9 @@ begin
       begin
         argsArray[i]:=Trim(argsArray[i]);
         if argsArray[i][findStartPos]='(' then
-          argsArray[i]:=Copy(argsArray[i],findStartPos+1, Length(argsArray[i]));
+          argsArray[i]:=trim(Copy(argsArray[i],findStartPos+1, Length(argsArray[i])));
         if argsArray[i][findEndPos(argsArray[i])]=')' then
-          argsArray[i]:=Copy(argsArray[i], findStartPos, Length(argsArray[i])-1);
+          argsArray[i]:=trim(Copy(argsArray[i], findStartPos, Length(argsArray[i])-1));
       end;
 
       if (UpperCase(item)='G') or (UpperCase(item)='G2') then


### PR DESCRIPTION
Signed-off-by: Pierre Pede <p.pede@pipcom.de>
Found this issue when playing around with demo. If you choose keymatch_model.conf together with keymatch_policy.csv the enforcement will not work for example with "alice, /alice_data/data, GET"

The problem is that keymatch function is trying to compare " /alice_data/data" with  "/alice_data/*".
The result ist false. Doing the same in casbin editor [https://casbin.org/editor/] the result is true.

After fix in Casbin.Resolve.pas the result is the same.