### PR TITLE
Improve matcher: add effect to array if no allow or deny is provided

### DIFF
--- a/Demos/Console/ConsoleDemo.dpr
+++ b/Demos/Console/ConsoleDemo.dpr
@@ -18,11 +18,11 @@ begin
     casbin:=TCasbin.Create('..\..\rbac_with_deny_model.conf','');
     with casbin.Policy do
     begin
-      addPolicy(stPolicyRules, 'p, superuser, user, add, allow');
-      addPolicy(stPolicyRules, 'p, superuser, user, delete, allow');
+      addPolicy(stPolicyRules, 'p, applicationManager, user, add, allow');
+      addPolicy(stPolicyRules, 'p, applicationManager, user, delete, allow');
       addPolicy(stPolicyRules, 'p, alice, user, delete, deny');
-      addPolicy(stPolicyRules, 'g, alice, superuser');
-      addPolicy(stPolicyRules, 'g, bob, superuser');
+      addPolicy(stPolicyRules, 'g, alice, applicationManager');
+      addPolicy(stPolicyRules, 'g, bob, applicationManager');
     end;
 
     Assert(casbin.enforce(['alice', 'user', 'add']) = true);

--- a/SourceCode/Common/Casbin/Casbin.pas
+++ b/SourceCode/Common/Casbin/Casbin.pas
@@ -309,18 +309,20 @@ begin
           if matcherResult = erAllow then
           begin
             if policyList.count = request.Count then
-              matcherResult:=erAllow
+            begin
+              matcherResult:=erAllow;
+            end
             else
             begin
               var f: string :=  policyList[request.Count];
               if policyList.Count > request.Count then
-                if UpperCase(policyList[request.Count]) = 'ALLOW' then
+                if SameText(Trim(policyList[request.Count]), 'ALLOW') then
                   matcherResult:=erAllow
                 else
                   matcherResult:=erDeny;
-              SetLength(effectArray, Length(effectArray)+1);
-              effectArray[Length(effectArray)-1]:=matcherResult; //PALOFF
             end;
+            SetLength(effectArray, Length(effectArray)+1);
+            effectArray[Length(effectArray)-1]:=matcherResult; //PALOFF
           end;
         end;
         policyDict.Free;

--- a/Tests/Tests.Casbin.Main.pas
+++ b/Tests/Tests.Casbin.Main.pas
@@ -143,11 +143,9 @@ type
 {$ENDREGION}
 {$REGION 'TestKeyMatchModelDeny'}
     // From enforce_test.go - TestKeyMatchModelInMemoryDeny
-    // In the original GO test, it reports the expected value should be true
-    // but it must be wrong????? This returns false
     [TestCase ('KeyMatchDeny.1','..\..\..\Examples\Tests\keymatch_model_Deny.conf#'+
                             '..\..\..\Examples\Tests\keymatch_policy.csv#'+
-                            'alice,/alice_data/resource2,POST#false', '#')]
+                            'alice,/alice_data/resource2,POST#true', '#')]
 {$ENDREGION}
 {$REGION 'TestBasicModelWithRoot'}
     // From model_test.go - TestBasicModelWithRoot


### PR DESCRIPTION
- Improve matcher: add effect to array if no allow or deny is provided
- Don't use superuser in console (conflicts with the internal superuser/admin)
- Fix KeyMatchDeny which somehow now works the same way it does in go