### PR TITLE
fix keymatch

### DIFF
--- a/SourceCode/Common/Functions/Casbin.Functions.KeyMatch.pas
+++ b/SourceCode/Common/Functions/Casbin.Functions.KeyMatch.pas
@@ -31,7 +31,7 @@ begin
   if index=0 then
     Exit(key1 = key2);
 
-  if Length(key1) > index then
+  if Length(key1) >= index then
     Exit(Copy(key1, low(string), index-1) = Copy(key2, low(string), index-1));
 
   Exit(key1 = Copy(key2, low(string), index-1));

--- a/Tests/Tests.Functions.pas
+++ b/Tests/Tests.Functions.pas
@@ -49,6 +49,7 @@ type
     [TestCase('KeyMatch-7', '/foobar,/foo,false')]
     [TestCase('KeyMatch-8', '/foobar,/foo*,true')]
     [TestCase('KeyMatch-9', '/foobar,/foo/*,false')]
+    [TestCase('KeyMatch-10', '/foo/b,/foo/*,true')]
     procedure testKeyMatch(const aKey1, aKey2: string; const aResult: boolean);
 
     [Test]
@@ -78,6 +79,7 @@ type
     [TestCase('KeyMatch2-21', '/alice/all,/:id/all,true')]
     [TestCase('KeyMatch2-22', '/alice,/:id/all,false')]
     [TestCase('KeyMatch2-23', '/alice/all,/:id,false')]
+    [TestCase('KeyMatch2-24', '/foo/b,/foo/*,true')]
     procedure testKeyMatch2(const aKey1, aKey2: string; const aResult: boolean);
 
     [Test]


### PR DESCRIPTION
keymatch doesn't work for this case policy `foo/*` and access resource `foo/b`.
This PR fixes the comparison.